### PR TITLE
Update own pool

### DIFF
--- a/drivers/tee/optee/Makefile
+++ b/drivers/tee/optee/Makefile
@@ -4,3 +4,4 @@ optee-objs += call.o
 optee-objs += rpc.o
 optee-objs += supp.o
 optee-objs += bench.o
+optee-objs += shm_pool.o

--- a/drivers/tee/optee/call.c
+++ b/drivers/tee/optee/call.c
@@ -480,20 +480,21 @@ void optee_fill_pages_list(u64 *dst, struct page **pages, size_t num_pages)
 }
 
 /* Number of user pages + number of pages to hold list of user pages  */
-#define GET_ARRAY_SIZE(num_entries) \
-	sizeof(u64) * (num_entries + (sizeof(u64) * num_entries) / PAGE_SIZE)
+size_t get_pages_array_size(size_t num_entries)
+{
+	return sizeof(u64) *
+		(num_entries + (sizeof(u64) * num_entries) / PAGE_SIZE);
+}
 
 void *optee_allocate_pages_array(size_t num_entries)
 {
-	return alloc_pages_exact(GET_ARRAY_SIZE(num_entries), GFP_KERNEL);
+	return alloc_pages_exact(get_pages_array_size(num_entries), GFP_KERNEL);
 }
 
 void optee_free_pages_array(void *array, size_t num_entries)
 {
-	free_pages_exact(array, GET_ARRAY_SIZE(num_entries));
+	free_pages_exact(array, get_pages_array_size(num_entries));
 }
-
-#undef GET_ARRAY_SIZE
 
 int optee_shm_register(struct tee_device *teedev, struct tee_shm *shm,
 		struct page **pages, size_t num_pages)
@@ -521,11 +522,11 @@ int optee_shm_register(struct tee_device *teedev, struct tee_shm *shm,
 
 	msg_arg->cmd = OPTEE_MSG_CMD_REGISTER_SHM;
 	msg_arg->params->attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT |
-		OPTEE_MSG_ATTR_NONCONTIG;
+				OPTEE_MSG_ATTR_NONCONTIG;
 	msg_arg->params->u.tmem.shm_ref = (unsigned long)shm;
 	msg_arg->params->u.tmem.size = tee_shm_get_size(shm);
 	msg_arg->params->u.tmem.buf_ptr = virt_to_phys(pages_array) |
-		tee_shm_get_page_offset(shm);
+					  tee_shm_get_page_offset(shm);
 
 	if (optee_do_call_with_arg(teedev, msg_parg) ||
 	    msg_arg->ret != TEEC_SUCCESS)

--- a/drivers/tee/optee/call.c
+++ b/drivers/tee/optee/call.c
@@ -479,9 +479,9 @@ void optee_fill_pages_list(u64 *dst, struct page **pages, size_t num_pages)
 	}
 }
 
-/* Number of user pages + number of pages to hold list of user pages  */
-size_t get_pages_array_size(size_t num_entries)
+static size_t get_pages_array_size(size_t num_entries)
 {
+	/* Number of user pages + number of pages to hold list of user pages  */
 	return sizeof(u64) *
 		(num_entries + (sizeof(u64) * num_entries) / PAGE_SIZE);
 }

--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -98,10 +98,76 @@ int optee_from_msg_param(struct tee_param *params, size_t num_params,
 					return rc;
 			}
 			break;
+		case OPTEE_MSG_ATTR_TYPE_RMEM_INPUT:
+		case OPTEE_MSG_ATTR_TYPE_RMEM_OUTPUT:
+		case OPTEE_MSG_ATTR_TYPE_RMEM_INOUT:
+			p->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT +
+				attr - OPTEE_MSG_ATTR_TYPE_RMEM_INPUT;
+			p->u.memref.size = mp->u.rmem.size;
+			shm = (struct tee_shm *)(unsigned long)
+				mp->u.rmem.shm_ref;
+
+			if (!shm) {
+				p->u.memref.shm_offs = 0;
+				p->u.memref.shm = NULL;
+				break;
+			}
+			p->u.memref.shm_offs = mp->u.rmem.offs;
+			p->u.memref.shm = shm;
+
+			/* Check that the memref is covered by the shm object */
+			if (p->u.memref.size) {
+				size_t o = p->u.memref.shm_offs +
+					p->u.memref.size;
+				if (o > tee_shm_get_size(shm))
+					return -EINVAL;
+			}
+			break;
+
 		default:
 			return -EINVAL;
 		}
 	}
+	return 0;
+}
+
+static int to_msg_param_tmp_mem(struct optee_msg_param *mp,
+				const struct tee_param *p)
+{
+	int rc;
+	phys_addr_t pa;
+
+	mp->attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT + p->attr -
+		   TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT;
+
+	mp->u.tmem.shm_ref = (unsigned long)p->u.memref.shm;
+	mp->u.tmem.size = p->u.memref.size;
+
+	if (!p->u.memref.shm) {
+		mp->u.tmem.buf_ptr = 0;
+		return 0;
+	}
+
+	rc = tee_shm_get_pa(p->u.memref.shm, p->u.memref.shm_offs, &pa);
+	if (rc)
+		return rc;
+
+	mp->u.tmem.buf_ptr = pa;
+	mp->attr |= OPTEE_MSG_ATTR_CACHE_PREDEFINED <<
+		    OPTEE_MSG_ATTR_CACHE_SHIFT;
+
+	return 0;
+}
+
+static int to_msg_param_reg_mem(struct optee_msg_param *mp,
+				const struct tee_param *p)
+{
+	mp->attr = OPTEE_MSG_ATTR_TYPE_RMEM_INPUT + p->attr -
+		   TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT;
+
+	mp->u.rmem.shm_ref = (unsigned long)p->u.memref.shm;
+	mp->u.rmem.size = p->u.memref.size;
+	mp->u.rmem.offs = p->u.memref.shm_offs;
 	return 0;
 }
 
@@ -117,7 +183,6 @@ int optee_to_msg_param(struct optee_msg_param *msg_params, size_t num_params,
 {
 	int rc;
 	size_t n;
-	phys_addr_t pa;
 
 	for (n = 0; n < num_params; n++) {
 		const struct tee_param *p = params + n;
@@ -140,22 +205,12 @@ int optee_to_msg_param(struct optee_msg_param *msg_params, size_t num_params,
 		case TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT:
 		case TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT:
 		case TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INOUT:
-			mp->attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT +
-				   p->attr -
-				   TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT;
-			mp->u.tmem.shm_ref = (unsigned long)p->u.memref.shm;
-			mp->u.tmem.size = p->u.memref.size;
-			if (!p->u.memref.shm) {
-				mp->u.tmem.buf_ptr = 0;
-				break;
-			}
-			rc = tee_shm_get_pa(p->u.memref.shm,
-					    p->u.memref.shm_offs, &pa);
+			if (tee_shm_is_registered(p->u.memref.shm))
+				rc = to_msg_param_reg_mem(mp, p);
+			else
+				rc = to_msg_param_tmp_mem(mp, p);
 			if (rc)
 				return rc;
-			mp->u.tmem.buf_ptr = pa;
-			mp->attr |= OPTEE_MSG_ATTR_CACHE_PREDEFINED <<
-					OPTEE_MSG_ATTR_CACHE_SHIFT;
 			break;
 		default:
 			return -EINVAL;
@@ -172,6 +227,10 @@ static void optee_get_version(struct tee_device *teedev,
 		.impl_caps = TEE_OPTEE_CAP_TZ,
 		.gen_caps = TEE_GEN_CAP_GP,
 	};
+	struct optee *optee = tee_get_drvdata(teedev);
+
+	if (optee->sec_caps & OPTEE_SMC_SEC_CAP_REGISTER_SHM)
+		v.gen_caps |= TEE_GEN_CAP_REG_MEM;
 	*vers = v;
 }
 
@@ -221,7 +280,7 @@ static void optee_release(struct tee_context *ctx)
 	if (!ctxdata)
 		return;
 
-	shm = tee_shm_alloc(ctx, sizeof(struct optee_msg_arg), TEE_SHM_MAPPED);
+	shm = tee_shm_priv_alloc(teedev, sizeof(struct optee_msg_arg));
 	if (!IS_ERR(shm)) {
 		arg = tee_shm_get_va(shm, 0);
 		/*
@@ -241,7 +300,7 @@ static void optee_release(struct tee_context *ctx)
 			memset(arg, 0, sizeof(*arg));
 			arg->cmd = OPTEE_MSG_CMD_CLOSE_SESSION;
 			arg->session = sess->session_id;
-			optee_do_call_with_arg(ctx, parg);
+			optee_do_call_with_arg(teedev, parg);
 		}
 		kfree(sess);
 	}
@@ -264,6 +323,8 @@ static struct tee_driver_ops optee_ops = {
 	.close_session = optee_close_session,
 	.invoke_func = optee_invoke_func,
 	.cancel_req = optee_cancel_req,
+	.shm_register = optee_shm_register,
+	.shm_unregister = optee_shm_unregister,
 };
 
 static struct tee_desc optee_desc = {
@@ -278,6 +339,8 @@ static struct tee_driver_ops optee_supp_ops = {
 	.release = optee_release,
 	.supp_recv = optee_supp_recv,
 	.supp_send = optee_supp_send,
+	.shm_register = optee_shm_register,
+	.shm_unregister = optee_shm_unregister,
 };
 
 static struct tee_desc optee_supp_desc = {
@@ -490,6 +553,7 @@ static struct optee *optee_probe(struct device_node *np)
 	}
 
 	optee->invoke_fn = invoke_fn;
+	optee->sec_caps = sec_caps;
 
 	teedev = tee_device_alloc(&optee_desc, NULL, pool, optee);
 	if (IS_ERR(teedev)) {

--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -472,6 +472,7 @@ optee_config_shm_memremap(optee_invoke_fn *invoke_fn, void **memremaped_shm,
 
 		vaddr += sz;
 		paddr += sz;
+		size -= sz;
 	}
 
 	rc = tee_shm_pool_mgr_alloc_res_mem(vaddr, paddr, size, PAGE_SHIFT);

--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -231,7 +231,7 @@ static void optee_get_version(struct tee_device *teedev,
 	};
 	struct optee *optee = tee_get_drvdata(teedev);
 
-	if (optee->sec_caps & OPTEE_SMC_SEC_CAP_REGISTER_SHM)
+	if (optee->sec_caps & OPTEE_SMC_SEC_CAP_DYNAMIC_SHM)
 		v.gen_caps |= TEE_GEN_CAP_REG_MEM;
 	*vers = v;
 }
@@ -460,7 +460,7 @@ optee_config_shm_memremap(optee_invoke_fn *invoke_fn, void **memremaped_shm,
 	dmabuf_info.size = size - OPTEE_SHM_NUM_PRIV_PAGES * PAGE_SIZE;
 
 	/* If OP-TEE can work with unregistered SHM, we will use own pool */
-	if (sec_caps & OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM)
+	if (sec_caps & OPTEE_SMC_SEC_CAP_DYNAMIC_SHM)
 		pool = optee_shm_get_pool(&dmabuf_info);
 	else
 		pool = tee_shm_pool_alloc_res_mem(&priv_info, &dmabuf_info);

--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -104,7 +104,7 @@ int optee_from_msg_param(struct tee_param *params, size_t num_params,
 		case OPTEE_MSG_ATTR_TYPE_RMEM_OUTPUT:
 		case OPTEE_MSG_ATTR_TYPE_RMEM_INOUT:
 			p->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT +
-				attr - OPTEE_MSG_ATTR_TYPE_RMEM_INPUT;
+				  attr - OPTEE_MSG_ATTR_TYPE_RMEM_INPUT;
 			p->u.memref.size = mp->u.rmem.size;
 			shm = (struct tee_shm *)(unsigned long)
 				mp->u.rmem.shm_ref;
@@ -120,7 +120,7 @@ int optee_from_msg_param(struct tee_param *params, size_t num_params,
 			/* Check that the memref is covered by the shm object */
 			if (p->u.memref.size) {
 				size_t o = p->u.memref.shm_offs +
-					p->u.memref.size;
+					   p->u.memref.size;
 				if (o > tee_shm_get_size(shm))
 					return -EINVAL;
 			}

--- a/drivers/tee/optee/optee_msg.h
+++ b/drivers/tee/optee/optee_msg.h
@@ -55,6 +55,11 @@
 #define OPTEE_MSG_ATTR_TYPE_TMEM_INPUT		0x9
 #define OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT		0xa
 #define OPTEE_MSG_ATTR_TYPE_TMEM_INOUT		0xb
+/*
+ * Special parameter type denoting that command buffer continues on
+ * specified page
+ */
+#define OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENT	0xc
 
 #define OPTEE_MSG_ATTR_TYPE_MASK		GENMASK(7, 0)
 

--- a/drivers/tee/optee/optee_msg.h
+++ b/drivers/tee/optee/optee_msg.h
@@ -61,6 +61,9 @@
  */
 #define OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENT	0xc
 
+/* Special parameter type that points to real command buffer */
+#define OPTEE_MSG_ATTR_TYPE_NESTED		0xd
+
 #define OPTEE_MSG_ATTR_TYPE_MASK		GENMASK(7, 0)
 
 /*
@@ -77,6 +80,12 @@
  * that doesn't have this bit set.
  */
 #define OPTEE_MSG_ATTR_FRAGMENT			BIT(9)
+
+/*
+ * The shared memory object holds array of struct optee_param with actual
+ * parameters.
+ */
+#define OPTEE_MSG_ATTR_NESTED			BIT(10)
 
 /*
  * Memory attributes for caching passed with temp memrefs. The actual value
@@ -142,6 +151,18 @@ struct optee_msg_param_value {
 };
 
 /**
+ * struct optee_msg_param_nested - nested params
+ * @buf_ptr: Address of the buffer with nested params
+ * @params_num: Number of nested params
+ * @shm_ref: Shared memory reference, pointer to a struct tee_shm
+ */
+struct optee_msg_param_nested {
+	uint64_t buf_ptr;
+	uint64_t params_num;
+	uint64_t shm_ref;
+};
+
+/**
  * struct optee_msg_param - parameter used together with struct optee_msg_arg
  * @attr:	attributes
  * @tmem:	parameter by temporary memory reference
@@ -150,8 +171,9 @@ struct optee_msg_param_value {
  *
  * @attr & OPTEE_MSG_ATTR_TYPE_MASK indicates if tmem, rmem or value is used in
  * the union. OPTEE_MSG_ATTR_TYPE_VALUE_* indicates value,
- * OPTEE_MSG_ATTR_TYPE_TMEM_* indicates tmem and
- * OPTEE_MSG_ATTR_TYPE_RMEM_* indicates rmem.
+ * OPTEE_MSG_ATTR_TYPE_TMEM_* indicates @tmem and
+ * OPTEE_MSG_ATTR_TYPE_RMEM_* indicates @rmem,
+ * OPTEE_MSG_ATTR_TYPE_NESTED indicates @nested parameters.
  * OPTEE_MSG_ATTR_TYPE_NONE indicates that none of the members are used.
  */
 struct optee_msg_param {
@@ -160,6 +182,7 @@ struct optee_msg_param {
 		struct optee_msg_param_tmem tmem;
 		struct optee_msg_param_rmem rmem;
 		struct optee_msg_param_value value;
+		struct optee_msg_param_nested nested;
 	} u;
 };
 

--- a/drivers/tee/optee/optee_msg.h
+++ b/drivers/tee/optee/optee_msg.h
@@ -71,7 +71,7 @@
  * Used with OPTEE_MSG_ATTR_TYPE_TMEM_*.
  * buf_ptr should point to the beginning of the buffer. Buffer will contain
  * list of page addresses. OP-TEE core can reconstruct contigous buffer from
- * that page adresses list. Page addresses are stored as 64 bit values.
+ * that page addresses list. Page addresses are stored as 64 bit values.
  * Last entry on a page should point to the next page of buffer.
  * 12 least significant of buf_ptr should hold page offset of user buffer.
  */
@@ -151,7 +151,6 @@ struct optee_msg_param_value {
  * the union. OPTEE_MSG_ATTR_TYPE_VALUE_* indicates value,
  * OPTEE_MSG_ATTR_TYPE_TMEM_* indicates @tmem and
  * OPTEE_MSG_ATTR_TYPE_RMEM_* indicates @rmem,
- * OPTEE_MSG_ATTR_TYPE_NESTED indicates @nested parameters.
  * OPTEE_MSG_ATTR_TYPE_NONE indicates that none of the members are used.
  */
 struct optee_msg_param {

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -83,7 +83,9 @@ struct optee_supp {
  *			secure world sync object
  * @supp:		supplicant synchronization struct for RPC to supplicant
  * @pool:		shared memory pool
- * @memremaped_shm	virtual address of memory in shared memory pool
+ * @ioremaped_shm:	virtual address of memory in shared memory pool
+ * @sec_caps:		secure world capabilities defined by
+ *			OPTEE_SMC_SEC_CAP_* in optee_smc.h
  */
 struct optee {
 	struct tee_device *supp_teedev;
@@ -94,6 +96,7 @@ struct optee {
 	struct optee_supp supp;
 	struct tee_shm_pool *pool;
 	void *memremaped_shm;
+	u32 sec_caps;
 };
 
 struct optee_session {
@@ -118,12 +121,12 @@ struct optee_rpc_param {
 	u32	a7;
 };
 
-void optee_handle_rpc(struct tee_context *ctx, struct optee_rpc_param *param);
+void optee_handle_rpc(struct tee_device *teedev, struct optee_rpc_param *param);
 
 void optee_wait_queue_init(struct optee_wait_queue *wq);
 void optee_wait_queue_exit(struct optee_wait_queue *wq);
 
-u32 optee_supp_thrd_req(struct tee_context *ctx, u32 func, size_t num_params,
+u32 optee_supp_thrd_req(struct optee *optee, u32 func, size_t num_params,
 			struct tee_param *param);
 
 int optee_supp_read(struct tee_context *ctx, void __user *buf, size_t len);
@@ -137,7 +140,7 @@ int optee_supp_recv(struct tee_context *ctx, u32 *func, u32 *num_params,
 int optee_supp_send(struct tee_context *ctx, u32 ret, u32 num_params,
 		    struct tee_param *param);
 
-u32 optee_do_call_with_arg(struct tee_context *ctx, phys_addr_t parg);
+u32 optee_do_call_with_arg(struct tee_device *teedev, phys_addr_t parg);
 int optee_open_session(struct tee_context *ctx,
 		       struct tee_ioctl_open_session_arg *arg,
 		       struct tee_param *param);
@@ -149,10 +152,18 @@ int optee_cancel_req(struct tee_context *ctx, u32 cancel_id, u32 session);
 void optee_enable_shm_cache(struct optee *optee);
 void optee_disable_shm_cache(struct optee *optee);
 
+int optee_shm_register(struct tee_device *teedev, struct tee_shm *shm,
+		       struct page **pages, size_t num_pages);
+int optee_shm_unregister(struct tee_device *teedev, struct tee_shm *shm);
+
 int optee_from_msg_param(struct tee_param *params, size_t num_params,
 			 const struct optee_msg_param *msg_params);
 int optee_to_msg_param(struct optee_msg_param *msg_params, size_t num_params,
 		       const struct tee_param *params);
+
+bool optee_fill_mem_ref_param(struct optee_msg_param *msg_params, uint32_t attr,
+			      struct page **pages, size_t num_pages,
+			      struct tee_shm *shm);
 
 /*
  * Small helpers

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -121,7 +121,16 @@ struct optee_rpc_param {
 	u32	a7;
 };
 
-void optee_handle_rpc(struct tee_device *teedev, struct optee_rpc_param *param);
+/* Holds context that is preserved during one STD call */
+struct optee_call_ctx {
+	/* information about page array used in last allocation */
+	void *pages_array;
+	size_t num_entries;
+};
+
+void optee_handle_rpc(struct tee_device *teedev, struct optee_rpc_param *param,
+		      struct optee_call_ctx *call_ctx);
+void optee_rpc_finalize_call(struct optee_call_ctx *call_ctx);
 
 void optee_wait_queue_init(struct optee_wait_queue *wq);
 void optee_wait_queue_exit(struct optee_wait_queue *wq);
@@ -165,21 +174,9 @@ int optee_from_msg_param(struct tee_param *params, size_t num_params,
 int optee_to_msg_param(struct optee_msg_param *msg_params, size_t num_params,
 		       const struct tee_param *params);
 
-bool optee_fill_mem_ref_param(struct optee_msg_param *msg_params, uint32_t attr,
-			      struct page **pages, size_t num_pages,
-			      struct tee_shm *shm);
-
-/**
- * optee_round_up_params_count() - round up number of parameters to fit
- * service entries (OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENTx)
- *
- * @num_params - number of actual parameters
- * @pg_offset - offset of parameters array within a page
- *
- * return:
- *   how many parameters to allocate
- */
-size_t optee_round_up_params_count(size_t num_params, size_t pg_offset);
+void *optee_allocate_pages_array(size_t num_entries);
+void optee_free_pages_array(void *array, size_t num_entries);
+void optee_fill_pages_list(u64 *dst, struct page **pages, size_t num_pages);
 
 /*
  * Small helpers

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -156,6 +156,10 @@ int optee_shm_register(struct tee_device *teedev, struct tee_shm *shm,
 		       struct page **pages, size_t num_pages);
 int optee_shm_unregister(struct tee_device *teedev, struct tee_shm *shm);
 
+int optee_shm_register_supp(struct tee_device *teedev, struct tee_shm *shm,
+			    struct page **pages, size_t num_pages);
+int optee_shm_unregister_supp(struct tee_device *teedev, struct tee_shm *shm);
+
 int optee_from_msg_param(struct tee_param *params, size_t num_params,
 			 const struct optee_msg_param *msg_params);
 int optee_to_msg_param(struct optee_msg_param *msg_params, size_t num_params,
@@ -164,6 +168,18 @@ int optee_to_msg_param(struct optee_msg_param *msg_params, size_t num_params,
 bool optee_fill_mem_ref_param(struct optee_msg_param *msg_params, uint32_t attr,
 			      struct page **pages, size_t num_pages,
 			      struct tee_shm *shm);
+
+/**
+ * optee_round_up_params_count() - round up number of parameters to fit
+ * service entries (OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENTx)
+ *
+ * @num_params - number of actual parameters
+ * @pg_offset - offset of parameters array within a page
+ *
+ * return:
+ *   how many parameters to allocate
+ */
+size_t optee_round_up_params_count(size_t num_params, size_t pg_offset);
 
 /*
  * Small helpers

--- a/drivers/tee/optee/optee_smc.h
+++ b/drivers/tee/optee/optee_smc.h
@@ -222,6 +222,8 @@ struct optee_smc_get_shm_config_result {
 #define OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM	BIT(0)
 /* Secure world can communicate via previously unregistered shared memory */
 #define OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM	BIT(1)
+/* Secure world supports registration of shared memory */
+#define OPTEE_SMC_SEC_CAP_REGISTER_SHM		BIT(2)
 #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	9
 #define OPTEE_SMC_EXCHANGE_CAPABILITIES \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES)

--- a/drivers/tee/optee/optee_smc.h
+++ b/drivers/tee/optee/optee_smc.h
@@ -222,8 +222,13 @@ struct optee_smc_get_shm_config_result {
 #define OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM	BIT(0)
 /* Secure world can communicate via previously unregistered shared memory */
 #define OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM	BIT(1)
-/* Secure world supports registration of shared memory */
-#define OPTEE_SMC_SEC_CAP_REGISTER_SHM		BIT(2)
+
+/*
+ * Secure world supports commands "register/unregister shared memory",
+ * secure world accepts command buffers located in any parts of non-secure RAM
+ */
+#define OPTEE_SMC_SEC_CAP_DYNAMIC_SHM		BIT(2)
+
 #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	9
 #define OPTEE_SMC_EXCHANGE_CAPABILITIES \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES)

--- a/drivers/tee/optee/rpc.c
+++ b/drivers/tee/optee/rpc.c
@@ -212,8 +212,6 @@ static void handle_rpc_func_cmd_shm_alloc(struct tee_device *teedev,
 	size_t sz;
 	size_t n;
 
-	BUG_ON(!call_ctx || call_ctx->pages_array || call_ctx->num_entries);
-
 	arg->ret_origin = TEEC_ORIGIN_COMMS;
 
 	if (!arg->num_params ||
@@ -275,9 +273,9 @@ static void handle_rpc_func_cmd_shm_alloc(struct tee_device *teedev,
 		call_ctx->num_entries = page_num;
 
 		arg->params[0].attr =  OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT |
-			OPTEE_MSG_ATTR_NONCONTIG;
-		arg->params[0].u.tmem.buf_ptr = virt_to_phys(pages_array)
-			+ tee_shm_get_page_offset(shm);
+				       OPTEE_MSG_ATTR_NONCONTIG;
+		arg->params[0].u.tmem.buf_ptr = virt_to_phys(pages_array) +
+						tee_shm_get_page_offset(shm);
 
 		arg->params[0].u.tmem.size = tee_shm_get_size(shm);
 		arg->params[0].u.tmem.shm_ref = (unsigned long)shm;
@@ -407,8 +405,9 @@ void optee_rpc_finalize_call(struct optee_call_ctx *call_ctx)
 	free_page_array(call_ctx);
 }
 
-static void handle_rpc_func_cmd(struct tee_device* teedev, struct optee *optee,
-				struct tee_shm *shm, struct optee_call_ctx *call_ctx)
+static void handle_rpc_func_cmd(struct tee_device *teedev, struct optee *optee,
+				struct tee_shm *shm,
+				struct optee_call_ctx *call_ctx)
 {
 	struct optee_msg_arg *arg;
 
@@ -420,7 +419,6 @@ static void handle_rpc_func_cmd(struct tee_device* teedev, struct optee *optee,
 
 	switch (arg->cmd) {
 	case OPTEE_MSG_RPC_CMD_GET_TIME:
-		free_page_array(call_ctx);
 		handle_rpc_func_cmd_get_time(arg);
 		break;
 	case OPTEE_MSG_RPC_CMD_WAIT_QUEUE:
@@ -434,14 +432,12 @@ static void handle_rpc_func_cmd(struct tee_device* teedev, struct optee *optee,
 		handle_rpc_func_cmd_shm_alloc(teedev, arg, call_ctx);
 		break;
 	case OPTEE_MSG_RPC_CMD_SHM_FREE:
-		free_page_array(call_ctx);
 		handle_rpc_func_cmd_shm_free(teedev, arg);
 		break;
 	case OPTEE_MSG_RPC_CMD_BENCH_REG:
 		handle_rpc_func_cmd_bm_reg(arg);
 		break;
 	default:
-		free_page_array(call_ctx);
 		handle_rpc_supp_cmd(optee, arg);
 	}
 }

--- a/drivers/tee/optee/shm_pool.c
+++ b/drivers/tee/optee/shm_pool.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2016, EPAM Systems
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#include <linux/device.h>
+#include <linux/dma-buf.h>
+#include <linux/genalloc.h>
+#include <linux/slab.h>
+#include <linux/tee_drv.h>
+#include "optee_private.h"
+#include "optee_smc.h"
+#include "shm_pool.h"
+
+static int pool_op_alloc(struct tee_shm_pool_mgr *poolm,
+			 struct tee_shm *shm, size_t size)
+{
+	unsigned int order = get_order(size);
+	struct page *page;
+
+	page = alloc_pages(GFP_KERNEL | __GFP_ZERO, order);
+	if (!page)
+		return -ENOMEM;
+
+	shm->kaddr = page_address(page);
+	shm->paddr = page_to_phys(page);
+	shm->size = PAGE_SIZE << order;
+
+	return 0;
+}
+
+static void pool_op_free(struct tee_shm_pool_mgr *poolm,
+			     struct tee_shm *shm)
+{
+	free_pages((unsigned long)shm->kaddr, get_order(shm->size));
+	shm->kaddr = NULL;
+}
+
+static const struct tee_shm_pool_mgr_ops pool_ops = {
+	.alloc = pool_op_alloc,
+	.free = pool_op_free,
+};
+
+static int pool_priv_mgr_init(struct tee_shm_pool_mgr *mgr, void *priv)
+{
+	mgr->ops = &pool_ops;
+	mgr->private_data = priv;
+	return 0;
+}
+
+static int pool_op_dma_alloc(struct tee_shm_pool_mgr *poolm,
+			     struct tee_shm *shm, size_t size)
+{
+	unsigned long va;
+	struct gen_pool *genpool = poolm->private_data;
+	size_t s = roundup(size, 1 << genpool->min_alloc_order);
+
+	va = gen_pool_alloc(genpool, s);
+	if (!va)
+		return -ENOMEM;
+
+	memset((void *)va, 0, s);
+	shm->kaddr = (void *)va;
+	shm->paddr = gen_pool_virt_to_phys(genpool, va);
+	shm->size = s;
+	return 0;
+}
+
+static void pool_op_dma_free(struct tee_shm_pool_mgr *poolm,
+			     struct tee_shm *shm)
+{
+	gen_pool_free(poolm->private_data, (unsigned long)shm->kaddr,
+		      shm->size);
+	shm->kaddr = NULL;
+}
+
+static const struct tee_shm_pool_mgr_ops pool_ops_dma = {
+	.alloc = pool_op_dma_alloc,
+	.free = pool_op_dma_free,
+};
+
+static void pool_destroy(struct tee_shm_pool *pool)
+{
+	gen_pool_destroy(pool->dma_buf_mgr.private_data);
+}
+
+static int pool_dma_mgr_init(struct tee_shm_pool_mgr *mgr,
+				 struct tee_shm_pool_mem_info *info,
+				 int min_alloc_order)
+{
+	size_t page_mask = PAGE_SIZE - 1;
+	struct gen_pool *genpool = NULL;
+	int rc;
+
+	/*
+	 * Start and end must be page aligned
+	 */
+	if ((info->vaddr & page_mask) || (info->paddr & page_mask) ||
+	    (info->size & page_mask))
+		return -EINVAL;
+
+	genpool = gen_pool_create(min_alloc_order, -1);
+	if (!genpool)
+		return -ENOMEM;
+
+	gen_pool_set_algo(genpool, gen_pool_best_fit, NULL);
+	rc = gen_pool_add_virt(genpool, info->vaddr, info->paddr, info->size,
+			       -1);
+	if (rc) {
+		gen_pool_destroy(genpool);
+		return rc;
+	}
+
+	mgr->private_data = genpool;
+	mgr->ops = &pool_ops_dma;
+	return 0;
+}
+
+struct tee_shm_pool *
+optee_shm_get_pool(struct tee_shm_pool_mem_info *dmabuf_info)
+{
+	struct tee_shm_pool *pool = NULL;
+	int ret;
+
+	pool = kzalloc(sizeof(*pool), GFP_KERNEL);
+	if (!pool) {
+		ret = -ENOMEM;
+		goto err;
+	}
+
+	/*
+	 * Create the pool for driver private shared memory
+	 */
+	ret = pool_priv_mgr_init(&pool->private_mgr, NULL);
+	if (ret)
+		goto err;
+
+	/*
+	 * Create the pool for dma_buf shared memory
+	 */
+	ret = pool_dma_mgr_init(&pool->dma_buf_mgr, dmabuf_info,
+				PAGE_SHIFT);
+	if (ret)
+		goto err;
+
+	pool->destroy = pool_destroy;
+	return pool;
+err:
+	if (ret == -ENOMEM)
+		pr_err("can't allocate memory for res_mem shared memory pool\n");
+	kfree(pool);
+	return ERR_PTR(ret);
+}
+
+void optee_shm_pool_free(struct tee_shm_pool *pool)
+{
+	pool->destroy(pool);
+	kfree(pool);
+}

--- a/drivers/tee/optee/shm_pool.c
+++ b/drivers/tee/optee/shm_pool.c
@@ -45,124 +45,25 @@ static void pool_op_free(struct tee_shm_pool_mgr *poolm,
 	shm->kaddr = NULL;
 }
 
+static void pool_op_destroy_poolmgr(struct tee_shm_pool_mgr *poolm)
+{
+	kfree(poolm);
+}
+
 static const struct tee_shm_pool_mgr_ops pool_ops = {
 	.alloc = pool_op_alloc,
 	.free = pool_op_free,
+	.destroy_poolmgr = pool_op_destroy_poolmgr,
 };
 
-static int pool_priv_mgr_init(struct tee_shm_pool_mgr *mgr, void *priv)
+struct tee_shm_pool_mgr *optee_shm_pool_alloc_pages(void)
 {
+	struct tee_shm_pool_mgr *mgr = kzalloc(sizeof(*mgr), GFP_KERNEL);
+
+	if (!mgr)
+		return ERR_PTR(-ENOMEM);
+
 	mgr->ops = &pool_ops;
-	mgr->private_data = priv;
-	return 0;
-}
 
-static int pool_op_dma_alloc(struct tee_shm_pool_mgr *poolm,
-			     struct tee_shm *shm, size_t size)
-{
-	unsigned long va;
-	struct gen_pool *genpool = poolm->private_data;
-	size_t s = roundup(size, 1 << genpool->min_alloc_order);
-
-	va = gen_pool_alloc(genpool, s);
-	if (!va)
-		return -ENOMEM;
-
-	memset((void *)va, 0, s);
-	shm->kaddr = (void *)va;
-	shm->paddr = gen_pool_virt_to_phys(genpool, va);
-	shm->size = s;
-	return 0;
-}
-
-static void pool_op_dma_free(struct tee_shm_pool_mgr *poolm,
-			     struct tee_shm *shm)
-{
-	gen_pool_free(poolm->private_data, (unsigned long)shm->kaddr,
-		      shm->size);
-	shm->kaddr = NULL;
-}
-
-static const struct tee_shm_pool_mgr_ops pool_ops_dma = {
-	.alloc = pool_op_dma_alloc,
-	.free = pool_op_dma_free,
-};
-
-static void pool_destroy(struct tee_shm_pool *pool)
-{
-	gen_pool_destroy(pool->dma_buf_mgr.private_data);
-}
-
-static int pool_dma_mgr_init(struct tee_shm_pool_mgr *mgr,
-				 struct tee_shm_pool_mem_info *info,
-				 int min_alloc_order)
-{
-	size_t page_mask = PAGE_SIZE - 1;
-	struct gen_pool *genpool = NULL;
-	int rc;
-
-	/*
-	 * Start and end must be page aligned
-	 */
-	if ((info->vaddr & page_mask) || (info->paddr & page_mask) ||
-	    (info->size & page_mask))
-		return -EINVAL;
-
-	genpool = gen_pool_create(min_alloc_order, -1);
-	if (!genpool)
-		return -ENOMEM;
-
-	gen_pool_set_algo(genpool, gen_pool_best_fit, NULL);
-	rc = gen_pool_add_virt(genpool, info->vaddr, info->paddr, info->size,
-			       -1);
-	if (rc) {
-		gen_pool_destroy(genpool);
-		return rc;
-	}
-
-	mgr->private_data = genpool;
-	mgr->ops = &pool_ops_dma;
-	return 0;
-}
-
-struct tee_shm_pool *
-optee_shm_get_pool(struct tee_shm_pool_mem_info *dmabuf_info)
-{
-	struct tee_shm_pool *pool = NULL;
-	int ret;
-
-	pool = kzalloc(sizeof(*pool), GFP_KERNEL);
-	if (!pool) {
-		ret = -ENOMEM;
-		goto err;
-	}
-
-	/*
-	 * Create the pool for driver private shared memory
-	 */
-	ret = pool_priv_mgr_init(&pool->private_mgr, NULL);
-	if (ret)
-		goto err;
-
-	/*
-	 * Create the pool for dma_buf shared memory
-	 */
-	ret = pool_dma_mgr_init(&pool->dma_buf_mgr, dmabuf_info,
-				PAGE_SHIFT);
-	if (ret)
-		goto err;
-
-	pool->destroy = pool_destroy;
-	return pool;
-err:
-	if (ret == -ENOMEM)
-		pr_err("can't allocate memory for res_mem shared memory pool\n");
-	kfree(pool);
-	return ERR_PTR(ret);
-}
-
-void optee_shm_pool_free(struct tee_shm_pool *pool)
-{
-	pool->destroy(pool);
-	kfree(pool);
+	return mgr;
 }

--- a/drivers/tee/optee/shm_pool.h
+++ b/drivers/tee/optee/shm_pool.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2016, EPAM Systems
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#ifndef SHM_POOL_H
+#define SHM_POOL_H
+#include "../tee_private.h"
+
+struct tee_shm_pool *
+optee_shm_get_pool(struct tee_shm_pool_mem_info *dmabuf_info);
+
+void optee_shm_pool_free(struct tee_shm_pool *pool);
+
+#endif

--- a/drivers/tee/optee/shm_pool.h
+++ b/drivers/tee/optee/shm_pool.h
@@ -15,11 +15,9 @@
 
 #ifndef SHM_POOL_H
 #define SHM_POOL_H
-#include "../tee_private.h"
 
-struct tee_shm_pool *
-optee_shm_get_pool(struct tee_shm_pool_mem_info *dmabuf_info);
+#include <linux/tee_drv.h>
 
-void optee_shm_pool_free(struct tee_shm_pool *pool);
+struct tee_shm_pool_mgr *optee_shm_pool_alloc_pages(void);
 
 #endif

--- a/drivers/tee/optee/supp.c
+++ b/drivers/tee/optee/supp.c
@@ -82,11 +82,10 @@ void optee_supp_release(struct optee_supp *supp)
  *
  * Returns result of operation to be passed to secure world
  */
-u32 optee_supp_thrd_req(struct tee_context *ctx, u32 func, size_t num_params,
+u32 optee_supp_thrd_req(struct optee *optee, u32 func, size_t num_params,
 			struct tee_param *param)
 
 {
-	struct optee *optee = tee_get_drvdata(ctx->teedev);
 	struct optee_supp *supp = &optee->supp;
 	struct optee_supp_req *req = kzalloc(sizeof(*req), GFP_KERNEL);
 	bool interruptable;

--- a/drivers/tee/tee_core.c
+++ b/drivers/tee/tee_core.c
@@ -127,8 +127,6 @@ static int tee_ioctl_shm_alloc(struct tee_context *ctx,
 	if (data.flags)
 		return -EINVAL;
 
-	data.id = -1;
-
 	shm = tee_shm_alloc(ctx, data.size, TEE_SHM_MAPPED | TEE_SHM_DMA_BUF);
 	if (IS_ERR(shm))
 		return PTR_ERR(shm);
@@ -142,6 +140,43 @@ static int tee_ioctl_shm_alloc(struct tee_context *ctx,
 	else
 		ret = tee_shm_get_fd(shm);
 
+	/*
+	 * When user space closes the file descriptor the shared memory
+	 * should be freed or if tee_shm_get_fd() failed then it will
+	 * be freed immediately.
+	 */
+	tee_shm_put(shm);
+	return ret;
+}
+
+static int
+tee_ioctl_shm_register(struct tee_context *ctx,
+		       struct tee_ioctl_shm_register_data __user *udata)
+{
+	long ret;
+	struct tee_ioctl_shm_register_data data;
+	struct tee_shm *shm;
+
+	if (copy_from_user(&data, udata, sizeof(data)))
+		return -EFAULT;
+
+	/* Currently no input flags are supported */
+	if (data.flags)
+		return -EINVAL;
+
+	shm = tee_shm_register(ctx, data.addr, data.length,
+			       TEE_SHM_DMA_BUF | TEE_SHM_USER_MAPPED);
+	if (IS_ERR(shm))
+		return PTR_ERR(shm);
+
+	data.id = shm->id;
+	data.flags = shm->flags;
+	data.length = shm->size;
+
+	if (copy_to_user(udata, &data, sizeof(data)))
+		ret = -EFAULT;
+	else
+		ret = tee_shm_get_fd(shm);
 	/*
 	 * When user space closes the file descriptor the shared memory
 	 * should be freed or if tee_shm_get_fd() failed then it will
@@ -627,6 +662,8 @@ static long tee_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		return tee_ioctl_version(ctx, uarg);
 	case TEE_IOC_SHM_ALLOC:
 		return tee_ioctl_shm_alloc(ctx, uarg);
+	case TEE_IOC_SHM_REGISTER:
+		return tee_ioctl_shm_register(ctx, uarg);
 	case TEE_IOC_SHM_REGISTER_FD:
 		return tee_ioctl_shm_register_fd(ctx, uarg);
 	case TEE_IOC_OPEN_SESSION:

--- a/drivers/tee/tee_private.h
+++ b/drivers/tee/tee_private.h
@@ -37,6 +37,7 @@ struct tee_device;
  * @dmabuf:	dmabuf used to for exporting to user space
  * @flags:	defined by TEE_SHM_* in tee_drv.h
  * @id:		unique id of a shared memory object on this device
+ * @vmapped:	userspace pages were mapped to kernel
  */
 struct tee_shm {
 	struct tee_device *teedev;
@@ -51,6 +52,7 @@ struct tee_shm {
 	struct dma_buf *dmabuf;
 	u32 flags;
 	int id;
+	bool vmapped;
 };
 
 struct tee_shm_pool_mgr;

--- a/drivers/tee/tee_private.h
+++ b/drivers/tee/tee_private.h
@@ -31,6 +31,9 @@ struct tee_device;
  * @paddr:	physical address of the shared memory
  * @kaddr:	virtual address of the shared memory
  * @size:	size of shared memory
+ * @offset:	offset of buffer in user space
+ * @pages:     locked pages from userspace
+ * @num_pages: number of locked pages
  * @dmabuf:	dmabuf used to for exporting to user space
  * @flags:	defined by TEE_SHM_* in tee_drv.h
  * @id:		unique id of a shared memory object on this device
@@ -42,6 +45,9 @@ struct tee_shm {
 	phys_addr_t paddr;
 	void *kaddr;
 	size_t size;
+	unsigned int offset;
+	struct page **pages;
+	size_t num_pages;
 	struct dma_buf *dmabuf;
 	u32 flags;
 	int id;

--- a/drivers/tee/tee_private.h
+++ b/drivers/tee/tee_private.h
@@ -21,74 +21,15 @@
 #include <linux/mutex.h>
 #include <linux/types.h>
 
-struct tee_device;
-
-/**
- * struct tee_shm - shared memory object
- * @teedev:	device used to allocate the object
- * @ctx:	context using the object, if NULL the context is gone
- * @link	link element
- * @paddr:	physical address of the shared memory
- * @kaddr:	virtual address of the shared memory
- * @size:	size of shared memory
- * @offset:	offset of buffer in user space
- * @pages:     locked pages from userspace
- * @num_pages: number of locked pages
- * @dmabuf:	dmabuf used to for exporting to user space
- * @flags:	defined by TEE_SHM_* in tee_drv.h
- * @id:		unique id of a shared memory object on this device
- */
-struct tee_shm {
-	struct tee_device *teedev;
-	struct tee_context *ctx;
-	struct list_head link;
-	phys_addr_t paddr;
-	void *kaddr;
-	size_t size;
-	unsigned int offset;
-	struct page **pages;
-	size_t num_pages;
-	struct dma_buf *dmabuf;
-	u32 flags;
-	int id;
-};
-
-struct tee_shm_pool_mgr;
-
-/**
- * struct tee_shm_pool_mgr_ops - shared memory pool manager operations
- * @alloc:	called when allocating shared memory
- * @free:	called when freeing shared memory
- */
-struct tee_shm_pool_mgr_ops {
-	int (*alloc)(struct tee_shm_pool_mgr *poolmgr, struct tee_shm *shm,
-		     size_t size);
-	void (*free)(struct tee_shm_pool_mgr *poolmgr, struct tee_shm *shm);
-};
-
-/**
- * struct tee_shm_pool_mgr - shared memory manager
- * @ops:		operations
- * @private_data:	private data for the shared memory manager
- */
-struct tee_shm_pool_mgr {
-	const struct tee_shm_pool_mgr_ops *ops;
-	void *private_data;
-};
-
 /**
  * struct tee_shm_pool - shared memory pool
  * @private_mgr:	pool manager for shared memory only between kernel
  *			and secure world
  * @dma_buf_mgr:	pool manager for shared memory exported to user space
- * @destroy:		called when destroying the pool
- * @private_data:	private data for the pool
  */
 struct tee_shm_pool {
-	struct tee_shm_pool_mgr private_mgr;
-	struct tee_shm_pool_mgr dma_buf_mgr;
-	void (*destroy)(struct tee_shm_pool *pool);
-	void *private_data;
+	struct tee_shm_pool_mgr *private_mgr;
+	struct tee_shm_pool_mgr *dma_buf_mgr;
 };
 
 #define TEE_DEVICE_FLAG_REGISTERED	0x1

--- a/drivers/tee/tee_private.h
+++ b/drivers/tee/tee_private.h
@@ -37,7 +37,6 @@ struct tee_device;
  * @dmabuf:	dmabuf used to for exporting to user space
  * @flags:	defined by TEE_SHM_* in tee_drv.h
  * @id:		unique id of a shared memory object on this device
- * @vmapped:	userspace pages were mapped to kernel
  */
 struct tee_shm {
 	struct tee_device *teedev;
@@ -52,7 +51,6 @@ struct tee_shm {
 	struct dma_buf *dmabuf;
 	u32 flags;
 	int id;
-	bool vmapped;
 };
 
 struct tee_shm_pool_mgr;

--- a/drivers/tee/tee_shm.c
+++ b/drivers/tee/tee_shm.c
@@ -46,7 +46,7 @@ static void tee_shm_release(struct tee_shm *shm)
 					 DMA_BIDIRECTIONAL);
 		dma_buf_detach(shm->dmabuf, ref->attach);
 		dma_buf_put(ref->dmabuf);
-	} else {
+	} else if (shm->flags & TEE_SHM_POOL) {
 		struct tee_shm_pool_mgr *poolm;
 
 		if (shm->flags & TEE_SHM_DMA_BUF)
@@ -55,6 +55,12 @@ static void tee_shm_release(struct tee_shm *shm)
 			poolm = &teedev->pool->private_mgr;
 
 		poolm->ops->free(poolm, shm);
+	} else if (shm->flags & TEE_SHM_REGISTER) {
+		int rc = teedev->desc->ops->shm_unregister(teedev, shm);
+
+		if (rc)
+			dev_err(teedev->dev.parent,
+				"unregister shm %p failed: %d", shm, rc);
 	}
 
 	kfree(shm);
@@ -95,6 +101,10 @@ static int tee_shm_op_mmap(struct dma_buf *dmabuf, struct vm_area_struct *vma)
 	struct tee_shm *shm = dmabuf->priv;
 	size_t size = vma->vm_end - vma->vm_start;
 
+	/* Refuse sharing shared memory provided by application */
+	if (shm->flags & TEE_SHM_REGISTER)
+		return -EINVAL;
+
 	return remap_pfn_range(vma, vma->vm_start, shm->paddr >> PAGE_SHIFT,
 			       size, vma->vm_page_prot);
 }
@@ -108,25 +118,19 @@ static struct dma_buf_ops tee_shm_dma_buf_ops = {
 	.mmap = tee_shm_op_mmap,
 };
 
-/**
- * tee_shm_alloc() - Allocate shared memory
- * @ctx:	Context that allocates the shared memory
- * @size:	Requested size of shared memory
- * @flags:	Flags setting properties for the requested shared memory.
- *
- * Memory allocated as global shared memory is automatically freed when the
- * TEE file pointer is closed. The @flags field uses the bits defined by
- * TEE_SHM_* in <linux/tee_drv.h>. TEE_SHM_MAPPED must currently always be
- * set. If TEE_SHM_DMA_BUF global shared memory will be allocated and
- * associated with a dma-buf handle, else driver private memory.
- */
-struct tee_shm *tee_shm_alloc(struct tee_context *ctx, size_t size, u32 flags)
+struct tee_shm *__tee_shm_alloc(struct tee_context *ctx,
+				struct tee_device *teedev,
+				size_t size, u32 flags)
 {
-	struct tee_device *teedev = ctx->teedev;
 	struct tee_shm_pool_mgr *poolm = NULL;
 	struct tee_shm *shm;
 	void *ret;
 	int rc;
+
+	if (ctx && ctx->teedev != teedev) {
+		dev_err(teedev->dev.parent, "ctx and teedev mismatch\n");
+		return ERR_PTR(-EINVAL);
+	}
 
 	if (!(flags & TEE_SHM_MAPPED)) {
 		dev_err(teedev->dev.parent,
@@ -154,7 +158,7 @@ struct tee_shm *tee_shm_alloc(struct tee_context *ctx, size_t size, u32 flags)
 		goto err_dev_put;
 	}
 
-	shm->flags = flags;
+	shm->flags = flags | TEE_SHM_POOL;
 	shm->teedev = teedev;
 	shm->ctx = ctx;
 	if (flags & TEE_SHM_DMA_BUF)
@@ -190,9 +194,12 @@ struct tee_shm *tee_shm_alloc(struct tee_context *ctx, size_t size, u32 flags)
 			goto err_rem;
 		}
 	}
-	mutex_lock(&teedev->mutex);
-	list_add_tail(&shm->link, &ctx->list_shm);
-	mutex_unlock(&teedev->mutex);
+
+	if (ctx) {
+		mutex_lock(&teedev->mutex);
+		list_add_tail(&shm->link, &ctx->list_shm);
+		mutex_unlock(&teedev->mutex);
+	}
 
 	return shm;
 err_rem:
@@ -207,7 +214,137 @@ err_dev_put:
 	tee_device_put(teedev);
 	return ret;
 }
+/**
+ * tee_shm_alloc() - Allocate shared memory
+ * @ctx:	Context that allocates the shared memory
+ * @size:	Requested size of shared memory
+ * @flags:	Flags setting properties for the requested shared memory.
+ *
+ * Memory allocated as global shared memory is automatically freed when the
+ * TEE file pointer is closed. The @flags field uses the bits defined by
+ * TEE_SHM_* in <linux/tee_drv.h>. TEE_SHM_MAPPED must currently always be
+ * set. If TEE_SHM_DMA_BUF global shared memory will be allocated and
+ * associated with a dma-buf handle, else driver private memory.
+ */
+struct tee_shm *tee_shm_alloc(struct tee_context *ctx, size_t size, u32 flags)
+{
+	return __tee_shm_alloc(ctx, ctx->teedev, size, flags);
+}
 EXPORT_SYMBOL_GPL(tee_shm_alloc);
+
+struct tee_shm *tee_shm_priv_alloc(struct tee_device *teedev, size_t size)
+{
+	return __tee_shm_alloc(NULL, teedev, size, TEE_SHM_MAPPED);
+}
+EXPORT_SYMBOL_GPL(tee_shm_priv_alloc);
+
+struct tee_shm *tee_shm_register(struct tee_context *ctx, unsigned long addr,
+				 size_t length, u32 flags)
+{
+	struct tee_device *teedev = ctx->teedev;
+	u32 req_flags = TEE_SHM_DMA_BUF | TEE_SHM_USER_MAPPED;
+	struct tee_shm *shm;
+	void *ret;
+	int rc;
+	int num_pages;
+	unsigned long start;
+
+	if (flags != req_flags) {
+		dev_err(teedev->dev.parent, "invliad shm flags %#x", flags);
+		return ERR_PTR(-EINVAL);
+	}
+
+	if (!tee_device_get(teedev))
+		return ERR_PTR(-EINVAL);
+
+	if (!teedev->desc->ops->shm_register ||
+	    !teedev->desc->ops->shm_unregister) {
+		dev_err(teedev->dev.parent,
+			"register shared memory unspported by device");
+		tee_device_put(teedev);
+		return ERR_PTR(-EINVAL);
+	}
+
+	shm = kzalloc(sizeof(*shm), GFP_KERNEL);
+	if (!shm) {
+		ret = ERR_PTR(-ENOMEM);
+		goto err;
+	}
+
+	shm->flags = flags | TEE_SHM_REGISTER;
+	shm->teedev = teedev;
+	shm->ctx = ctx;
+	shm->id = -1;
+	start = rounddown(addr, PAGE_SIZE);
+	shm->offset = addr - start;
+	shm->size = length;
+	num_pages = (roundup(addr + length, PAGE_SIZE) - start) / PAGE_SIZE;
+	shm->pages = kcalloc(num_pages, sizeof(struct page), GFP_KERNEL);
+	if (!shm->pages) {
+		ret = ERR_PTR(-ENOMEM);
+		goto err;
+	}
+
+	rc = get_user_pages_fast(start, num_pages, 1, shm->pages);
+	if (rc > 0)
+		shm->num_pages = rc;
+	if (rc != num_pages) {
+		if (rc > 0)
+			rc = -ENOMEM;
+		ret = ERR_PTR(rc);
+		goto err;
+	}
+
+	mutex_lock(&teedev->mutex);
+	shm->id = idr_alloc(&teedev->idr, shm, 1, 0, GFP_KERNEL);
+	mutex_unlock(&teedev->mutex);
+
+	rc = teedev->desc->ops->shm_register(teedev, shm, shm->pages,
+					     shm->num_pages);
+	if (rc) {
+		ret = ERR_PTR(rc);
+		goto err;
+	}
+
+	if (flags & TEE_SHM_DMA_BUF) {
+		DEFINE_DMA_BUF_EXPORT_INFO(exp_info);
+
+		exp_info.ops = &tee_shm_dma_buf_ops;
+		exp_info.size = shm->size;
+		exp_info.flags = O_RDWR;
+		exp_info.priv = shm;
+
+		shm->dmabuf = dma_buf_export(&exp_info);
+		if (IS_ERR(shm->dmabuf)) {
+			ret = ERR_CAST(shm->dmabuf);
+			teedev->desc->ops->shm_unregister(teedev, shm);
+			goto err;
+		}
+	}
+
+	mutex_lock(&teedev->mutex);
+	list_add_tail(&shm->link, &ctx->list_shm);
+	mutex_unlock(&teedev->mutex);
+
+	return shm;
+err:
+	if (shm) {
+		size_t n;
+
+		if (shm->id > 0) {
+			mutex_lock(&teedev->mutex);
+			idr_remove(&teedev->idr, shm->id);
+			mutex_unlock(&teedev->mutex);
+		}
+		for (n = 0; n < shm->num_pages; n++)
+			put_page(shm->pages[n]);
+		kfree(shm->pages);
+	}
+	kfree(shm);
+	tee_device_put(teedev);
+	return ret;
+}
+EXPORT_SYMBOL_GPL(tee_shm_register);
 
 struct tee_shm *tee_shm_register_fd(struct tee_context *ctx, int fd)
 {
@@ -452,6 +589,12 @@ struct tee_shm *tee_shm_get_from_id(struct tee_context *ctx, int id)
 	return shm;
 }
 EXPORT_SYMBOL_GPL(tee_shm_get_from_id);
+
+bool tee_shm_is_registered(struct tee_shm *shm)
+{
+	return shm && (shm->flags & TEE_SHM_REGISTER);
+}
+EXPORT_SYMBOL_GPL(tee_shm_is_registered);
 
 /**
  * tee_shm_get_id() - Get id of a shared memory object

--- a/drivers/tee/tee_shm.c
+++ b/drivers/tee/tee_shm.c
@@ -564,6 +564,28 @@ int tee_shm_get_pa(struct tee_shm *shm, size_t offs, phys_addr_t *pa)
 EXPORT_SYMBOL_GPL(tee_shm_get_pa);
 
 /**
+ * tee_shm_get_size() - Get size of shared memory buffer
+ * @shm:	Shared memory handle
+ * @returns size of shared memory
+ */
+ssize_t tee_shm_get_size(struct tee_shm *shm)
+{
+	return shm->size;
+}
+EXPORT_SYMBOL_GPL(tee_shm_get_size);
+
+/**
+ * tee_shm_get_page_offset() - Get shared buffer offset from page start
+ * @shm:	Shared memory handle
+ * @returns page offset of shared buffer
+ */
+ssize_t tee_shm_get_page_offset(struct tee_shm *shm)
+{
+	return shm->offset;
+}
+EXPORT_SYMBOL_GPL(tee_shm_get_page_offset);
+
+/**
  * tee_shm_get_from_id() - Find shared memory object and increase reference
  * count
  * @ctx:	Context owning the shared memory

--- a/drivers/tee/tee_shm.c
+++ b/drivers/tee/tee_shm.c
@@ -50,9 +50,9 @@ static void tee_shm_release(struct tee_shm *shm)
 		struct tee_shm_pool_mgr *poolm;
 
 		if (shm->flags & TEE_SHM_DMA_BUF)
-			poolm = &teedev->pool->dma_buf_mgr;
+			poolm = teedev->pool->dma_buf_mgr;
 		else
-			poolm = &teedev->pool->private_mgr;
+			poolm = teedev->pool->private_mgr;
 
 		poolm->ops->free(poolm, shm);
 	} else if (shm->flags & TEE_SHM_REGISTER) {
@@ -162,9 +162,9 @@ struct tee_shm *__tee_shm_alloc(struct tee_context *ctx,
 	shm->teedev = teedev;
 	shm->ctx = ctx;
 	if (flags & TEE_SHM_DMA_BUF)
-		poolm = &teedev->pool->dma_buf_mgr;
+		poolm = teedev->pool->dma_buf_mgr;
 	else
-		poolm = &teedev->pool->private_mgr;
+		poolm = teedev->pool->private_mgr;
 
 	rc = poolm->ops->alloc(poolm, shm, size);
 	if (rc) {

--- a/drivers/tee/tee_shm_pool.c
+++ b/drivers/tee/tee_shm_pool.c
@@ -146,7 +146,7 @@ struct tee_shm_pool_mgr *tee_shm_pool_mgr_alloc_res_mem(unsigned long vaddr,
 
 	mgr->ops = &pool_ops_generic;
 
-	return 0;
+	return mgr;
 err:
 	kfree(mgr);
 

--- a/drivers/tee/tee_shm_pool.c
+++ b/drivers/tee/tee_shm_pool.c
@@ -44,48 +44,17 @@ static void pool_op_gen_free(struct tee_shm_pool_mgr *poolm,
 	shm->kaddr = NULL;
 }
 
+static void pool_op_gen_destroy_poolmgr(struct tee_shm_pool_mgr *poolm)
+{
+	gen_pool_destroy(poolm->private_data);
+	kfree(poolm);
+}
+
 static const struct tee_shm_pool_mgr_ops pool_ops_generic = {
 	.alloc = pool_op_gen_alloc,
 	.free = pool_op_gen_free,
+	.destroy_poolmgr = pool_op_gen_destroy_poolmgr,
 };
-
-static void pool_res_mem_destroy(struct tee_shm_pool *pool)
-{
-	gen_pool_destroy(pool->private_mgr.private_data);
-	gen_pool_destroy(pool->dma_buf_mgr.private_data);
-}
-
-static int pool_res_mem_mgr_init(struct tee_shm_pool_mgr *mgr,
-				 struct tee_shm_pool_mem_info *info,
-				 int min_alloc_order)
-{
-	size_t page_mask = PAGE_SIZE - 1;
-	struct gen_pool *genpool = NULL;
-	int rc;
-
-	/*
-	 * Start and end must be page aligned
-	 */
-	if ((info->vaddr & page_mask) || (info->paddr & page_mask) ||
-	    (info->size & page_mask))
-		return -EINVAL;
-
-	genpool = gen_pool_create(min_alloc_order, -1);
-	if (!genpool)
-		return -ENOMEM;
-
-	gen_pool_set_algo(genpool, gen_pool_best_fit, NULL);
-	rc = gen_pool_add_virt(genpool, info->vaddr, info->paddr, info->size,
-			       -1);
-	if (rc) {
-		gen_pool_destroy(genpool);
-		return rc;
-	}
-
-	mgr->private_data = genpool;
-	mgr->ops = &pool_ops_generic;
-	return 0;
-}
 
 /**
  * tee_shm_pool_alloc_res_mem() - Create a shared memory pool from reserved
@@ -104,42 +73,111 @@ struct tee_shm_pool *
 tee_shm_pool_alloc_res_mem(struct tee_shm_pool_mem_info *priv_info,
 			   struct tee_shm_pool_mem_info *dmabuf_info)
 {
-	struct tee_shm_pool *pool = NULL;
-	int ret;
-
-	pool = kzalloc(sizeof(*pool), GFP_KERNEL);
-	if (!pool) {
-		ret = -ENOMEM;
-		goto err;
-	}
+	struct tee_shm_pool_mgr *priv_mgr;
+	struct tee_shm_pool_mgr *dmabuf_mgr;
+	void *rc;
 
 	/*
 	 * Create the pool for driver private shared memory
 	 */
-	ret = pool_res_mem_mgr_init(&pool->private_mgr, priv_info,
-				    3 /* 8 byte aligned */);
-	if (ret)
-		goto err;
+	rc = tee_shm_pool_mgr_alloc_res_mem(priv_info->vaddr, priv_info->paddr,
+					    priv_info->size,
+					    3 /* 8 byte aligned */);
+	if (IS_ERR(rc))
+		return rc;
+	priv_mgr = rc;
 
 	/*
 	 * Create the pool for dma_buf shared memory
 	 */
-	ret = pool_res_mem_mgr_init(&pool->dma_buf_mgr, dmabuf_info,
-				    PAGE_SHIFT);
-	if (ret)
-		goto err;
+	rc = tee_shm_pool_mgr_alloc_res_mem(dmabuf_info->vaddr,
+					    dmabuf_info->paddr,
+					    dmabuf_info->size, PAGE_SHIFT);
+	if (IS_ERR(rc))
+		goto err_free_priv_mgr;
+	dmabuf_mgr = rc;
 
-	pool->destroy = pool_res_mem_destroy;
-	return pool;
-err:
-	if (ret == -ENOMEM)
-		pr_err("%s: can't allocate memory for res_mem shared memory pool\n", __func__);
-	if (pool && pool->private_mgr.private_data)
-		gen_pool_destroy(pool->private_mgr.private_data);
-	kfree(pool);
-	return ERR_PTR(ret);
+	rc = tee_shm_pool_alloc(priv_mgr, dmabuf_mgr);
+	if (IS_ERR(rc))
+		goto err_free_dmabuf_mgr;
+
+	return rc;
+
+err_free_dmabuf_mgr:
+	tee_shm_pool_mgr_destroy(dmabuf_mgr);
+err_free_priv_mgr:
+	tee_shm_pool_mgr_destroy(priv_mgr);
+
+	return rc;
 }
 EXPORT_SYMBOL_GPL(tee_shm_pool_alloc_res_mem);
+
+struct tee_shm_pool_mgr *tee_shm_pool_mgr_alloc_res_mem(unsigned long vaddr,
+							phys_addr_t paddr,
+							size_t size,
+							int min_alloc_order)
+{
+	size_t page_mask = PAGE_SIZE - 1;
+	struct tee_shm_pool_mgr *mgr;
+	int rc;
+
+	/*
+	 * Start and end must be page aligned
+	 */
+	if ((vaddr & page_mask) || (paddr & page_mask) || (size & page_mask))
+		return ERR_PTR(-EINVAL);
+
+	mgr = kzalloc(sizeof(*mgr), GFP_KERNEL);
+	if (!mgr)
+		return ERR_PTR(-ENOMEM);
+
+	mgr->private_data = gen_pool_create(min_alloc_order, -1);
+	if (!mgr->private_data) {
+		rc = -ENOMEM;
+		goto err;
+	}
+
+	gen_pool_set_algo(mgr->private_data, gen_pool_best_fit, NULL);
+	rc = gen_pool_add_virt(mgr->private_data, vaddr, paddr, size, -1);
+	if (rc) {
+		gen_pool_destroy(mgr->private_data);
+		goto err;
+	}
+
+	mgr->ops = &pool_ops_generic;
+
+	return 0;
+err:
+	kfree(mgr);
+
+	return ERR_PTR(rc);
+}
+EXPORT_SYMBOL_GPL(tee_shm_pool_mgr_alloc_res_mem);
+
+static bool check_mgr_ops(struct tee_shm_pool_mgr *mgr)
+{
+	return !mgr || (mgr->ops && mgr->ops->alloc && mgr->ops->free &&
+			mgr->ops->destroy_poolmgr);
+}
+
+struct tee_shm_pool *tee_shm_pool_alloc(struct tee_shm_pool_mgr *priv_mgr,
+					struct tee_shm_pool_mgr *dmabuf_mgr)
+{
+	struct tee_shm_pool *pool;
+
+	if (!check_mgr_ops(priv_mgr) || !check_mgr_ops(dmabuf_mgr))
+		return ERR_PTR(-EINVAL);
+
+	pool = kzalloc(sizeof(*pool), GFP_KERNEL);
+	if (!pool)
+		return ERR_PTR(-ENOMEM);
+
+	pool->private_mgr = priv_mgr;
+	pool->dma_buf_mgr = dmabuf_mgr;
+
+	return pool;
+}
+EXPORT_SYMBOL_GPL(tee_shm_pool_alloc);
 
 /**
  * tee_shm_pool_free() - Free a shared memory pool
@@ -150,7 +188,10 @@ EXPORT_SYMBOL_GPL(tee_shm_pool_alloc_res_mem);
  */
 void tee_shm_pool_free(struct tee_shm_pool *pool)
 {
-	pool->destroy(pool);
+	if (pool->private_mgr)
+		tee_shm_pool_mgr_destroy(pool->private_mgr);
+	if (pool->dma_buf_mgr)
+		tee_shm_pool_mgr_destroy(pool->dma_buf_mgr);
 	kfree(pool);
 }
 EXPORT_SYMBOL_GPL(tee_shm_pool_free);

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -28,6 +28,9 @@
 #define TEE_SHM_MAPPED		BIT(0)	/* Memory mapped by the kernel */
 #define TEE_SHM_DMA_BUF		BIT(1)	/* Memory with dma-buf handle */
 #define TEE_SHM_EXT_DMA_BUF	BIT(2)	/* Memory with dma-buf handle */
+#define TEE_SHM_REGISTER	BIT(3)  /* Memory registered in secure world */
+#define TEE_SHM_USER_MAPPED	BIT(4)  /* Memory mapped in user space */
+#define TEE_SHM_POOL		BIT(5)  /* Memory allocated from pool */
 
 struct tee_device;
 struct tee_shm;
@@ -76,6 +79,8 @@ struct tee_param {
  * @cancel_req:		request cancel of an ongoing invoke or open
  * @supp_revc:		called for supplicant to get a command
  * @supp_send:		called for supplicant to send a response
+ * @shm_register:	register shared memory buffer in TEE
+ * @shm_unregister:	unregister shared memory buffer in TEE
  */
 struct tee_driver_ops {
 	void (*get_version)(struct tee_device *teedev,
@@ -94,6 +99,9 @@ struct tee_driver_ops {
 			 struct tee_param *param);
 	int (*supp_send)(struct tee_context *ctx, u32 ret, u32 num_params,
 			 struct tee_param *param);
+	int (*shm_register)(struct tee_device *teedev, struct tee_shm *shm,
+			    struct page **pages, size_t num_pages);
+	int (*shm_unregister)(struct tee_device *teedev, struct tee_shm *shm);
 };
 
 /**
@@ -211,6 +219,29 @@ void *tee_get_drvdata(struct tee_device *teedev);
 struct tee_shm *tee_shm_alloc(struct tee_context *ctx, size_t size, u32 flags);
 
 /**
+ * tee_shm_priv_alloc() - Allocate shared memory privately
+ * @dev:	Device that allocates the shared memory
+ * @size:	Requested size of shared memory
+ *
+ * Allocates shared memory buffer that is not associated with any client
+ * context. Such buffers are owned by TEE driver and used for internal calls.
+ *
+ * @returns a pointer to 'struct tee_shm'
+ */
+struct tee_shm *tee_shm_priv_alloc(struct tee_device *teedev, size_t size);
+
+/**
+ * tee_shm_register() - Register shared memory buffer
+ * @ctx:	Context that registers the shared memory
+ * @addr:	Address is userspace of the shared buffer
+ * @length:	Length of the shared buffer
+ * @flags:	Flags setting properties for the requested shared memory.
+ *
+ * @returns a pointer to 'struct tee_shm'
+ */
+struct tee_shm *tee_shm_register(struct tee_context *ctx, unsigned long addr,
+				 size_t length, u32 flags);
+/**
  * tee_shm_register_fd() - Register shared memory from file descriptor
  *
  * @ctx:	Context that allocates the shared memory
@@ -296,6 +327,13 @@ static inline bool tee_param_is_memref(struct tee_param *param)
 		return false;
 	}
 }
+
+/**
+ * tee_shm_is_registered() - Check if shared memory object in registered in TEE
+ * @shm:	Shared memory handle
+ * @returns true if object is registered in TEE
+ */
+bool tee_shm_is_registered(struct tee_shm *shm);
 
 struct tee_context *tee_client_open_context(struct tee_context *start,
 			int (*match)(struct tee_ioctl_version_data *,

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -291,6 +291,24 @@ int tee_shm_pa2va(struct tee_shm *shm, phys_addr_t pa, void **va);
 void *tee_shm_get_va(struct tee_shm *shm, size_t offs);
 
 /**
+ * tee_shm_vmap() - Map registered pages to kernel space
+ * @shm:	Shared memory handle
+ * @returns pointer to registered shared buffer in kernel address space
+ *	or ERR_PTR()
+ *
+ * This function is not thread safe and have no reference counter
+ */
+void *tee_shm_vmap(struct tee_shm *shm);
+
+/**
+ * tee_shm_vunmap() - Unmap registered pages from kernel space
+ * @shm:	Shared memory handle
+ *
+ * This function unmaps pages previously mapped by tee_shm_vmap().
+ */
+void tee_shm_vunmap(struct tee_shm *shm);
+
+/**
  * tee_shm_get_pa() - Get physical address of a shared memory plus an offset
  * @shm:	Shared memory handle
  * @offs:	Offset from start of this shared memory
@@ -306,6 +324,14 @@ int tee_shm_get_pa(struct tee_shm *shm, size_t offs, phys_addr_t *pa);
  * @returns size of shared memory
  */
 ssize_t tee_shm_get_size(struct tee_shm *shm);
+
+/**
+ * tee_shm_get_pages() - Get list of pages that hold shared buffer
+ * @shm:	Shared memory handle
+ * @num_pages:	Number of pages will be stored there
+ * @returns pointer to pages array
+ */
+struct page **tee_shm_get_pages(struct tee_shm *shm, size_t *num_pages);
 
 /**
  * tee_shm_get_page_offset() - Get shared buffer offset from page start

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -301,6 +301,20 @@ void *tee_shm_get_va(struct tee_shm *shm, size_t offs);
 int tee_shm_get_pa(struct tee_shm *shm, size_t offs, phys_addr_t *pa);
 
 /**
+ * tee_shm_get_size() - Get size of shared memory buffer
+ * @shm:	Shared memory handle
+ * @returns size of shared memory
+ */
+ssize_t tee_shm_get_size(struct tee_shm *shm);
+
+/**
+ * tee_shm_get_page_offset() - Get shared buffer offset from page start
+ * @shm:	Shared memory handle
+ * @returns page offset of shared buffer
+ */
+ssize_t tee_shm_get_page_offset(struct tee_shm *shm);
+
+/**
  * tee_shm_get_id() - Get id of a shared memory object
  * @shm:	Shared memory handle
  * @returns id

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -32,6 +32,7 @@
 #define TEE_SHM_USER_MAPPED	BIT(4)  /* Memory mapped in user space */
 #define TEE_SHM_POOL		BIT(5)  /* Memory allocated from pool */
 
+struct device;
 struct tee_device;
 struct tee_shm;
 struct tee_shm_pool;

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -159,6 +159,97 @@ int tee_device_register(struct tee_device *teedev);
 void tee_device_unregister(struct tee_device *teedev);
 
 /**
+ * struct tee_shm - shared memory object
+ * @teedev:	device used to allocate the object
+ * @ctx:	context using the object, if NULL the context is gone
+ * @link	link element
+ * @paddr:	physical address of the shared memory
+ * @kaddr:	virtual address of the shared memory
+ * @size:	size of shared memory
+ * @offset:	offset of buffer in user space
+ * @pages:	locked pages from userspace
+ * @num_pages:	number of locked pages
+ * @dmabuf:	dmabuf used to for exporting to user space
+ * @flags:	defined by TEE_SHM_* in tee_drv.h
+ * @id:		unique id of a shared memory object on this device
+ *
+ * This pool is only supposed to be accessed directly from the TEE
+ * subsystem and from drivers that implements their own shm pool manager.
+ */
+struct tee_shm {
+	struct tee_device *teedev;
+	struct tee_context *ctx;
+	struct list_head link;
+	phys_addr_t paddr;
+	void *kaddr;
+	size_t size;
+	unsigned int offset;
+	struct page **pages;
+	size_t num_pages;
+	struct dma_buf *dmabuf;
+	u32 flags;
+	int id;
+};
+
+/**
+ * struct tee_shm_pool_mgr - shared memory manager
+ * @ops:		operations
+ * @private_data:	private data for the shared memory manager
+ */
+struct tee_shm_pool_mgr {
+	const struct tee_shm_pool_mgr_ops *ops;
+	void *private_data;
+};
+
+/**
+ * struct tee_shm_pool_mgr_ops - shared memory pool manager operations
+ * @alloc:		called when allocating shared memory
+ * @free:		called when freeing shared memory
+ * @destroy_poolmgr:	called when destroying the pool manager
+ */
+struct tee_shm_pool_mgr_ops {
+	int (*alloc)(struct tee_shm_pool_mgr *poolmgr, struct tee_shm *shm,
+		     size_t size);
+	void (*free)(struct tee_shm_pool_mgr *poolmgr, struct tee_shm *shm);
+	void (*destroy_poolmgr)(struct tee_shm_pool_mgr *poolmgr);
+};
+
+/**
+ * tee_shm_pool_alloc() - Create a shared memory pool from shm managers
+ * @priv_mgr:	manager for driver private shared memory allocations
+ * @dmabuf_mgr:	manager for dma-buf shared memory allocations
+ *
+ * Allocation with the flag TEE_SHM_DMA_BUF set will use the range supplied
+ * in @dmabuf, others will use the range provided by @priv.
+ *
+ * @returns pointer to a 'struct tee_shm_pool' or an ERR_PTR on failure.
+ */
+struct tee_shm_pool *tee_shm_pool_alloc(struct tee_shm_pool_mgr *priv_mgr,
+					struct tee_shm_pool_mgr *dmabuf_mgr);
+
+/*
+ * tee_shm_pool_mgr_alloc_res_mem() - Create a shm manager for reserved
+ * memory
+ * @vaddr:	Virtual address of start of pool
+ * @paddr:	Physical address of start of pool
+ * @size:	Size in bytes of the pool
+ *
+ * @returns pointer to a 'struct tee_shm_pool_mgr' or an ERR_PTR on failure.
+ */
+struct tee_shm_pool_mgr *tee_shm_pool_mgr_alloc_res_mem(unsigned long vaddr,
+							phys_addr_t paddr,
+							size_t size,
+							int min_alloc_order);
+
+/**
+ * tee_shm_pool_mgr_destroy() - Free a shared memory manager
+ */
+static inline void tee_shm_pool_mgr_destroy(struct tee_shm_pool_mgr *poolm)
+{
+	poolm->ops->destroy_poolmgr(poolm);
+}
+
+/**
  * struct tee_shm_pool_mem_info - holds information needed to create a shared
  * memory pool
  * @vaddr:	Virtual address of start of pool

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -291,24 +291,6 @@ int tee_shm_pa2va(struct tee_shm *shm, phys_addr_t pa, void **va);
 void *tee_shm_get_va(struct tee_shm *shm, size_t offs);
 
 /**
- * tee_shm_vmap() - Map registered pages to kernel space
- * @shm:	Shared memory handle
- * @returns pointer to registered shared buffer in kernel address space
- *	or ERR_PTR()
- *
- * This function is not thread safe and have no reference counter
- */
-void *tee_shm_vmap(struct tee_shm *shm);
-
-/**
- * tee_shm_vunmap() - Unmap registered pages from kernel space
- * @shm:	Shared memory handle
- *
- * This function unmaps pages previously mapped by tee_shm_vmap().
- */
-void tee_shm_vunmap(struct tee_shm *shm);
-
-/**
  * tee_shm_get_pa() - Get physical address of a shared memory plus an offset
  * @shm:	Shared memory handle
  * @offs:	Offset from start of this shared memory

--- a/include/uapi/linux/tee.h
+++ b/include/uapi/linux/tee.h
@@ -50,6 +50,7 @@
 
 #define TEE_GEN_CAP_GP		(1 << 0)/* GlobalPlatform compliant TEE */
 #define TEE_GEN_CAP_PRIVILEGED	(1 << 1)/* Privileged device (for supplicant) */
+#define TEE_GEN_CAP_REG_MEM	(1 << 2)/* Supports registering shared memory */
 
 /*
  * TEE Implementation ID
@@ -144,6 +145,36 @@ struct tee_ioctl_shm_register_fd_data {
  */
 #define TEE_IOC_SHM_REGISTER_FD	_IOWR(TEE_IOC_MAGIC, TEE_IOC_BASE + 8, \
 				     struct tee_ioctl_shm_register_fd_data)
+
+/**
+ * struct tee_shm_register_data - Shared memory register argument
+ * @addr:      [in] Start address of shared memory to register
+ * @length:    [in/out] Length of shared memory to register
+ * @flags:     [in/out] Flags to/from registration.
+ * @id:                [out] Identifier of the shared memory
+ *
+ * The flags field should currently be zero as input. Updated by the call
+ * with actual flags as defined by TEE_IOCTL_SHM_* above.
+ * This structure is used as argument for TEE_IOC_SHM_REGISTER below.
+ */
+struct tee_ioctl_shm_register_data {
+	__u64 addr;
+	__u64 length;
+	__u32 flags;
+	__s32 id;
+};
+
+/**
+ * TEE_IOC_SHM_REGISTER - Register shared memory argument
+ *
+ * Registers shared memory between the user space process and secure OS.
+ *
+ * Returns a file descriptor on success or < 0 on failure
+ *
+ * The shared memory is unregisterred when the descriptor is closed.
+ */
+#define TEE_IOC_SHM_REGISTER   _IOWR(TEE_IOC_MAGIC, TEE_IOC_BASE + 9, \
+				     struct tee_ioctl_shm_register_data)
 
 /**
  * struct tee_ioctl_buf_data - Variable sized buffer


### PR DESCRIPTION
The "tee: flexible shared memory  pool creation" will make adding an OP-TEE pool smoother.

The "tee: flexible shared memory  pool creation" commit should be rebased to before all the other commits in the `new_shm_rel` branch. Let's see how can deal with that later.